### PR TITLE
Message offset plus one

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The commit manager is exposed via a hook function (you don't need to be using Re
 ### Returned Functions
 
 - readyToCommit(data)
-  - data: This must be an object containing the properties "topic", "partition", and "offset".
+  - data: This must be an object containing the properties "topic", "partition", and "offset" from the Kafka mesage.
   - Call this whenever you are finished with a Kafka message.
 - onRebalance()
   - Call this whenever your KafkaConsumer has its partitions revoked.
@@ -96,7 +96,7 @@ consumer
   .connect();
 ```
 
-### Javascript
+### JavaScript
 
 ```JavaScript
 const { useCommitManager } = require("node-rdkafka-commit-manager");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka-commit-manager",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "prepare": "tsc",
     "test": "jest --collectCoverage"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka-commit-manager",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A simple helper for controlling when an offset is ready to be committed via node-rdkafka.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,13 +7,13 @@ describe("useCommitManager", () => {
   const SHORT_WAIT = 2;
   const LONGER_WAIT = 6;
   const offsetDescription1 = { topic: "abc", partition: 1, offset: 5 };
-  const message1 = { ...offsetDescription1, value: "test1" };
+  const message1 = { ...offsetDescription1, offset: 4, value: "test1" };
   const offsetDescription2 = { topic: "def", partition: 2, offset: 2 };
-  const message2 = { ...offsetDescription2, value: "test2" };
+  const message2 = { ...offsetDescription2, offset: 1, value: "test2" };
   const offsetDescription3 = { topic: "ghi", partition: 3, offset: 4 };
-  const message3 = { ...offsetDescription3, value: "test3" };
+  const message3 = { ...offsetDescription3, offset: 3, value: "test3" };
   const offsetDescription4 = { topic: "def", partition: 2, offset: 3 };
-  const message4 = { ...offsetDescription4, value: "test4" };
+  const message4 = { ...offsetDescription4, offset: 2, value: "test4" };
 
   it("only commits the first offset immediately", () => {
     // arrange

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export const useCommitManager = (
         ).map(([partition, offset]) => ({
           topic: topic,
           partition: parseInt(partition),
-          offset: offset
+          offset: offset + 1
         }));
         return accumulator.concat(partitionOffsetDescriptors);
       },


### PR DESCRIPTION
Previously, the commit manager was committing the offsets of the messages we were done with.
This resulted in behavior where, if you committed an offset, then started up a fresh consumer, it would receive the last message again.
The [librdkafka documentation on offset management](https://github.com/edenhill/librdkafka/wiki/Consumer-offset-management) states that we should be committing the offset one more than the latest message consumed.
The commit manager will now commit offsets one greater than the highest received via the readyToCommit function.